### PR TITLE
replace deprecated api `args()` with `arg()`

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -35,7 +35,7 @@ return {
 
 	entry = function(_, job)
 		local output = Command("oh-my-posh")
-			:args({
+			:arg({
 				"print",
 				"primary",
 				"--no-status",


### PR DESCRIPTION
`Command.args()` is deprecated by yazi, use `arg()` instead.