### PR TITLE
Replaced deprecated api ya.render() with ui.render()

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,7 +1,7 @@
 local save = ya.sync(function(st, cwd, output)
 	if cx.active.current.cwd == Url(cwd) then
 		st.output = output
-		ya.render()
+		ui.render()
 	end
 end)
 
@@ -49,3 +49,4 @@ return {
 		end
 	end,
 }
+


### PR DESCRIPTION
When opening yazi with omp.yazi installed a message appears stating that the api call ya.render() is deprecated and that ui.render() should be used instead. 

<img width="1133" height="642" alt="grafik" src="https://github.com/user-attachments/assets/ddf8e8e0-00fb-4548-8364-97bdebbb92bb" />

The change implements the new api call.